### PR TITLE
Fixed a small typo.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     author_email='senko.rasic@goodcode.io',
     description='Django Query Inspector',
     license='MIT',
-    url='github.com/dobarkod/django-queryinspect',
+    url='https://github.com/dobarkod/django-queryinspect',
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Web Environment",


### PR DESCRIPTION
Pypi needs the protocol in the URL.

See https://pypi.python.org/pypi/django-queryinspect
