### PR TITLE
added tox.ini for easy local testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /build/
 /dist/
 /*.egg-info/
+/.tox

--- a/README.md
+++ b/README.md
@@ -97,6 +97,19 @@ Since Django apps need not be under the same directory, the setting also
 accepts colon-separated list of directories - traceback entry referencing any
 file under any of these directories will be included.
 
+## Testing
+
+To run tests just use `tox` command (https://pypi.python.org/pypi/tox)
+
+    tox  # for all supported python and django versions
+
+If you need you can run tox just for single environment, f.i.:
+
+    tox -e py27_django17
+
+For available test environments refer to `tox.ini` file.
+
+
 ## License
 
 Copyright (C) 2014. Good Code and Django Query Inspector contributors

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,60 @@
+[tox]
+envlist = py26_django14, py26_django15, py26_django16,
+          py27_django14, py27_django15, py27_django16, py27_django17,
+          py33_django15, py33_django16, py33_django17,
+          py34_django15, py34_django16, py34_django17
+
+[testenv]
+commands = {envpython} setup.py test
+
+[testenv:py26_django14]
+basepython = python2.6
+deps = Django==1.4.13
+
+[testenv:py26_django15]
+basepython = python2.6
+deps = Django==1.5.8
+
+[testenv:py26_django16]
+basepython = python2.6
+deps = Django==1.6.5
+
+[testenv:py27_django14]
+basepython = python2.7
+deps = Django==1.4.13
+
+[testenv:py27_django15]
+basepython = python2.7
+deps = Django==1.5.8
+
+[testenv:py27_django16]
+basepython = python2.7
+deps = Django==1.6.5
+
+[testenv:py27_django17]
+basepython = python2.7
+deps = Django==1.7.1
+
+[testenv:py33_django15]
+basepython = python3.3
+deps = Django==1.5.8
+
+[testenv:py33_django16]
+basepython = python3.3
+deps = Django==1.6.5
+
+[testenv:py33_django17]
+basepython = python3.3
+deps = Django==1.7.1
+
+[testenv:py34_django15]
+basepython = python3.4
+deps = Django==1.5.8
+
+[testenv:py34_django16]
+basepython = python3.4
+deps = Django==1.6.5
+
+[testenv:py34_django17]
+basepython = python3.4
+deps = Django==1.7.1


### PR DESCRIPTION
I don't know other way to run tests on all python and django versions on my local machine, so I've added support for tox. Would it be useful?
