### PR TITLE
The `django.db.backends.util` module has been renamed.

### DIFF
--- a/qinspect/middleware.py
+++ b/qinspect/middleware.py
@@ -7,7 +7,7 @@ import math
 
 from django.conf import settings
 from django.db import connection
-from django.db.backends.util import CursorDebugWrapper
+from django.db.backends.utils import CursorDebugWrapper
 from django.core.exceptions import MiddlewareNotUsed
 
 if hasattr(logging, 'NullHandler'):

--- a/qinspect/middleware.py
+++ b/qinspect/middleware.py
@@ -7,8 +7,12 @@ import math
 
 from django.conf import settings
 from django.db import connection
-from django.db.backends.utils import CursorDebugWrapper
 from django.core.exceptions import MiddlewareNotUsed
+
+try:
+    from django.db.backends.utils import CursorDebugWrapper
+except ImportError:
+    from django.db.backends.util import CursorDebugWrapper
 
 if hasattr(logging, 'NullHandler'):
     NullHandler = logging.NullHandler


### PR DESCRIPTION
>The `django.db.backends.util` module has been renamed. Use `django.db.backends.utils` instead.