### PR TITLE
Update middleware.py

### DIFF
--- a/qinspect/middleware.py
+++ b/qinspect/middleware.py
@@ -195,6 +195,9 @@ class QueryInspectMiddleware(object):
         self.conn_queries_len = len(connection.queries)
 
     def process_response(self, request, response):
+        if not hasattr(self, "request_start"):
+            return response
+            
         request_time = time.time() - self.request_start
 
         infos = self.get_query_infos(


### PR DESCRIPTION
Fix for OPTIONS requests causing AttributeError with Django-rest-framework. No idea why, perhaps rest-framework does some funky stuff, but when using this middleware the first OPTIONS request doesn't seem to cause `process_request` to be called. This patch just checks if this is the case and prevents the exception from being raised by doing nothing.