### PR TITLE
Handle q['sql'] being None

### DIFF
--- a/qinspect/middleware.py
+++ b/qinspect/middleware.py
@@ -89,6 +89,9 @@ class QueryInspectMiddleware(MiddlewareMixin):
     def get_query_infos(cls, queries):
         retval = []
         for q in queries:
+            if q['sql'] is None:
+                continue
+                
             qi = cls.QueryInfo()
             qi.sql = cls.sql_id_pattern.sub('= ?', q['sql'])
             qi.time = float(q['time'])


### PR DESCRIPTION
I'm not sure why or how, but under some circumstances `sql` is None:

``` {'sql': None, 'time': '0.000'},
 {'sql': None, 'time': '0.000'},
 {'sql': None, 'time': '0.000'},
 {'sql': None, 'time': '0.000'},
 {'sql': None, 'time': '0.000'},
 {'sql': None, 'time': '0.000'},
 {'sql': None, 'time': '0.000'},
 {'sql': None, 'time': '0.000'},
```

This throws a regex error inside the middleware, and this MR fixes that.