### PR TITLE
Added new settings to enable logging of tracebacks for non duplicated queries

### DIFF
--- a/qinspect/middleware.py
+++ b/qinspect/middleware.py
@@ -38,6 +38,7 @@ cfg = dict(
     header_stats=getattr(settings, 'QUERY_INSPECT_HEADER_STATS', True),
     log_queries=getattr(settings, 'QUERY_INSPECT_LOG_QUERIES', False),
     log_tbs=getattr(settings, 'QUERY_INSPECT_LOG_TRACEBACKS', False),
+    duplicate_min=getattr(settings, 'QUERY_INSPECT_DUPLICATE_MIN', 1),
     roots=getattr(settings, 'QUERY_INSPECT_TRACEBACK_ROOTS', None),
     stddev_limit=getattr(settings, 'QUERY_INSPECT_STANDARD_DEVIATION_LIMIT',
         None),
@@ -116,7 +117,7 @@ class QueryInspectMiddleware(MiddlewareMixin):
     @classmethod
     def check_duplicates(cls, infos):
         duplicates = [(qi, num) for qi, num in cls.count_duplicates(infos)
-            if num > 1]
+            if num > cfg['duplicate_min']]
         duplicates.reverse()
         n = 0
         if len(duplicates) > 0:


### PR DESCRIPTION
I wanted to be able to log the tracebacks for all queries and thought perhaps a lower limit to enable this behaviour might be desirable? 