### PR TITLE
Implemented qinspect as a context manager.

### DIFF
--- a/qinspect/manager.py
+++ b/qinspect/manager.py
@@ -1,0 +1,31 @@
+import time
+from django.db import connection
+from qinspect.middleware import QueryInspectMiddleware, cfg
+
+
+class QueryInspectContextManager():
+    """
+    Code called within this context manager is profiled by django-queryinspect.
+    The results will be presented when the context manager exits.
+    """
+
+    def __enter__(self):
+        if cfg['enabled']:
+            self.request_start = time.time()
+            self.conn_queries_len = len(connection.queries)
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        if cfg['enabled']:
+            request_time = time.time() - self.request_start
+
+            infos = QueryInspectMiddleware.get_query_infos(
+                connection.queries[self.conn_queries_len:])
+
+            num_duplicates = QueryInspectMiddleware.check_duplicates(infos)
+            QueryInspectMiddleware.check_stddev_limit(infos)
+            QueryInspectMiddleware.check_absolute_limit(infos)
+            # Can call ootput_states() with response={} because the only thing
+            # it does to response is add keys.
+            QueryInspectMiddleware.output_stats(
+                infos, num_duplicates, request_time, {})

--- a/qinspect/middleware.py
+++ b/qinspect/middleware.py
@@ -140,6 +140,7 @@ class QueryInspectMiddleware(MiddlewareMixin):
 
         return n
 
+    @classmethod
     def check_stddev_limit(cls, infos):
         total = sum(qi.time for qi in infos)
         n = len(infos)


### PR DESCRIPTION
I adore django-queryinspect, but it can't be used in things like management commands or other non-request contexts (e.g. celery tasks), since it's a middleware. 

So I implemented the same functionality as a context manager. It worked great, so I figured I'd contribute it back to the original project.

I also fixed a small bug in `QueryInspectMiddleware`. `check_stddev_limit()` was clearly intended to be a classmethod, but the decorator was missing. I needed it to be a classmethod to make the context manager work, so I fixed that.